### PR TITLE
Added CI build for aarch64 for all patforms.

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -4,6 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
+        arch: [x86_64, aarch64]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{matrix.os}}
@@ -13,9 +14,12 @@ jobs:
         with:
           version: 0.10.0-dev.3027+0e26c6149
       - run: |
-          zig build test -Dfetch -Dci_target=${{matrix.os}}
+          zig build test -Dfetch -Dci_target=${{matrix.os}}-x86_64
+      - if: matrix.arch != 'x86_64'
+        run: |
+          zig build -Dfetch -Dci_target=${{matrix.os}}-${{matrix.arch}}
         shell: bash
       - uses: actions/upload-artifact@v2
         with:
-          name: zigup ${{ matrix.os }}
+          name: zigup ${{ matrix.os }}-${{ matrix.arch }}
           path: zig-out/bin/*

--- a/build2.zig
+++ b/build2.zig
@@ -194,7 +194,10 @@ fn join(b: *Builder, parts: []const []const u8) ![]const u8 {
 }
 
 const ci_target_map = std.ComptimeStringMap([]const u8, .{
-    .{ "ubuntu-latest", "x86_64-linux" },
-    .{ "macos-latest", "x86_64-macos" },
-    .{ "windows-latest", "x86_64-windows" },
+    .{ "ubuntu-latest-x86_64", "x86_64-linux" },
+    .{ "macos-latest-x86_64", "x86_64-macos" },
+    .{ "windows-latest-x86_64", "x86_64-windows" },
+    .{ "ubuntu-latest-arrch64", "aarch64-linux" },
+    .{ "macos-latest-aarch64", "aarch64-macos" },
+    .{ "windows-latest-aarch64", "aarch64-windows" },
 });

--- a/build2.zig
+++ b/build2.zig
@@ -197,7 +197,7 @@ const ci_target_map = std.ComptimeStringMap([]const u8, .{
     .{ "ubuntu-latest-x86_64", "x86_64-linux" },
     .{ "macos-latest-x86_64", "x86_64-macos" },
     .{ "windows-latest-x86_64", "x86_64-windows" },
-    .{ "ubuntu-latest-arrch64", "aarch64-linux" },
+    .{ "ubuntu-latest-aarch64", "aarch64-linux" },
     .{ "macos-latest-aarch64", "aarch64-macos" },
     .{ "windows-latest-aarch64", "aarch64-windows" },
 });


### PR DESCRIPTION
This commit resolves the problem where rosetta would run zigup and
download x86 binaries